### PR TITLE
Fix using and modifying same variable without a sequence point

### DIFF
--- a/Tedmem.cpp
+++ b/Tedmem.cpp
@@ -124,7 +124,7 @@ TED::TED() : filter(0), sidCard(0)
 void TED::Reset()
 {
 	// clear RAM with powerup pattern
-	for (int i=0;i<RAMSIZE;Ram[i++] = (i>>1)<<1==i ? 0 : 0xFF);
+	for (int i=0;i<RAMSIZE;Ram[i] = (i>>1)<<1==i ? 0 : 0xFF, i++);
 	// reset oscillators
 	oscillatorReset();
 	if (sidCard) sidCard->reset();
@@ -141,8 +141,10 @@ void TED::texttoscreen(int x,int y, const char *scrtxt)
 {
 	register int i =0;
 
-	while (scrtxt[i]!=0)
-		chrtoscreen(x+i*8,y,scrtxt[i++]);
+	while (scrtxt[i]!=0) {
+		chrtoscreen(x+i*8,y,scrtxt[i]);
+		i++;
+	}
 }
 
 void TED::chrtoscreen(int x,int y, char scrchr)


### PR DESCRIPTION
Code in `Tedmem.cpp` violates the sequence point rule in 2 places, where whether the side effiect (`i` to be increased by 1) happen before any uses of `i` is undefined; as a result these codes have undefined behaviors.

This error was discovered by following **g++(1)** warnings:
```
$ g++ -Wall -c Tedmem.cpp
Tedmem.cpp: In member function 'virtual void TED::Reset()':
Tedmem.cpp:127:55: warning: operation on 'i' may be undefined [-Wsequence-point]
Tedmem.cpp: In member function 'void TED::texttoscreen(int, int, const char*)':
Tedmem.cpp:145:35: warning: operation on 'i' may be undefined [-Wsequence-point]
...
```

I also suggest adding `-Werror=sequence-point` to **g++(1)** so it will become actual errors instead of just warnings, to prevent it from happening again:
```
g++ -Wall -Werror=sequence-point -c Tedmem.cpp
Tedmem.cpp: In member function 'virtual void TED::Reset()':
Tedmem.cpp:127:55: error: operation on 'i' may be undefined [-Werror=sequence-point]
Tedmem.cpp: In member function 'void TED::texttoscreen(int, int, const char*)':
Tedmem.cpp:145:35: error: operation on 'i' may be undefined [-Werror=sequence-point]
...
```